### PR TITLE
Add a test to reproduce link errors reported in gz/rust-x86#1

### DIFF
--- a/tests/no_std_build.rs
+++ b/tests/no_std_build.rs
@@ -1,0 +1,24 @@
+// Verify that we can be linked against an appliction which only uses
+// libcore, which is common in kernel space.
+
+#![feature(no_std, lang_items)]
+#![no_std]
+
+extern crate x86;
+
+fn main() {
+}
+
+// We want to supply these definitions ourselves, and not have them
+// accidentally pulled in via the x86 crate.
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {
+}
+
+#[lang = "panic_fmt"]
+extern "C" fn panic_fmt(
+    args: ::core::fmt::Arguments, file: &str, line: usize)
+    -> !
+{
+    loop {}
+}


### PR DESCRIPTION
Re: gz/rust-x86#1

THIS IS EXPECTED TO BREAK TRAVIS CI. :-)

This will cause `cargo test` to fail if any lang_items are being pulled
in by supporting crates.  This code is designed to simulate a typical OS
kernel written in Rust, using `#[no_std]` and custom `lang_items`.

Tested against rustc 1.6.0-nightly (cc3094872 2015-11-11).

Fixing this will make it much easier for beginner Rust OS developers to
use libx86 in more configurations.  But I haven't figured out what's
causing the error yet, only how to reproduce it.

Thank you for working on such a useful library!