### PR TITLE
Add convenience constructors for IdtEntry

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(no_std, core_str_ext, core_slice_ext)]
+#![feature(no_std, core_str_ext, core_slice_ext, const_fn)]
 #![feature(asm)]
 #![no_std]
 #![cfg_attr(test, allow(unused_features))]


### PR DESCRIPTION
(Here are the constructors I promised you. Thank you!)

It's really easy to create invalid IdtEntry values, and doing so usually
results in triple faults.  So in order to reduce kernel developer pain,
we provide two ready-made constructors:

1. A `missing` constructor, which can be used for unimplemented IDT
   entries.  This is a `const` fn, making it possible to statically-
   initialize an IdtEntry table at compile time.  (Note that we
   can't use `Default::default` for this, because trait methods can't
   be `const`.)
2. A `new` constructor, which takes a GDT code segment offset and
   a pointer to an interrupt handler, and installs it using the default
   flags.