### PR TITLE
Add a TLB module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,3 +42,4 @@ pub mod perfcnt;
 pub mod cpuid {
     pub use raw_cpuid::*;
 }
+pub mod tlb;

--- a/src/tlb.rs
+++ b/src/tlb.rs
@@ -1,0 +1,20 @@
+//! Functions to flush the translation lookaside buffer (TLB).
+
+/// Invalidate the given address in the TLB using the `invlpg` instruction.
+///
+/// # Safety
+/// This function is unsafe as it causes a general protection fault (GP) if the current privilege
+/// level is not 0.
+pub unsafe fn flush(addr: usize) {
+    asm!("invlpg ($0)" :: "r" (addr) : "memory" : "volatile");
+}
+
+/// Invalidate the TLB completely by reloading the CR3 register.
+///
+/// # Safety
+/// This function is unsafe as it causes a general protection fault (GP) if the current privilege
+/// level is not 0.
+pub unsafe fn flush_all() {
+    use controlregs::{cr3, cr3_write};
+    cr3_write(cr3())
+}


### PR DESCRIPTION
Adds a rudimentary module for flushing the translation lookaside buffer (TLB). The `flush` function uses the `invlpg` instruction and the `flush_all` function reloads the CR3 register.