### PR TITLE
Add method to retrieve current code segment selector

### DIFF
--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -205,3 +205,10 @@ pub unsafe fn load_cs(sel: SegmentSelector) {
          lretq
          1:" :: "r" (sel.bits() as u64) : "{rax}" "memory");
 }
+
+/// Returns the current value of the code segment register.
+pub fn cs() -> SegmentSelector {
+    let segment: u16;
+    unsafe { asm!("mov %cs, $0" : "=r" (segment) ) };
+    SegmentSelector::from_raw(segment)
+}


### PR DESCRIPTION
I hope that the inline assembly and the `Selector::from_raw` function are correct here…