### PR TITLE
Fix TableIndicator bit offset

### DIFF
--- a/src/shared/segmentation.rs
+++ b/src/shared/segmentation.rs
@@ -18,9 +18,9 @@ bitflags! {
         const RPL_3 = 0b11,
 
         /// Table Indicator (TI) 0 means GDT is used.
-        const TI_GDT = 0 << 3,
+        const TI_GDT = 0 << 2,
         /// Table Indicator (TI) 1 means LDT is used.
-        const TI_LDT = 1 << 3,
+        const TI_LDT = 1 << 2,
     }
 }
 


### PR DESCRIPTION
According to the mentioned Intel 3a, Section 3.4.2 "Segment Selectors", the TI bit is bit 2.