### PR TITLE
Structures are not considered immediates anymore

### DIFF
--- a/src/shared/segmentation.rs
+++ b/src/shared/segmentation.rs
@@ -107,27 +107,27 @@ impl fmt::Display for SegmentSelector {
 
 /// Reload stack segment register.
 pub unsafe fn load_ss(sel: SegmentSelector) {
-    asm!("movw $0, %ss " :: "r" (sel) : "memory");
+    asm!("movw $0, %ss " :: "r" (sel.bits()) : "memory");
 }
 
 /// Reload data segment register.
 pub unsafe fn load_ds(sel: SegmentSelector) {
-    asm!("movw $0, %ds " :: "r" (sel) : "memory");
+    asm!("movw $0, %ds " :: "r" (sel.bits()) : "memory");
 }
 
 /// Reload es segment register.
 pub unsafe fn load_es(sel: SegmentSelector) {
-    asm!("movw $0, %es " :: "r" (sel) : "memory");
+    asm!("movw $0, %es " :: "r" (sel.bits()) : "memory");
 }
 
 /// Reload fs segment register.
 pub unsafe fn load_fs(sel: SegmentSelector) {
-    asm!("movw $0, %fs " :: "r" (sel) : "memory");
+    asm!("movw $0, %fs " :: "r" (sel.bits()) : "memory");
 }
 
 /// Reload gs segment register.
 pub unsafe fn load_gs(sel: SegmentSelector) {
-    asm!("movw $0, %gs " :: "r" (sel) : "memory");
+    asm!("movw $0, %gs " :: "r" (sel.bits()) : "memory");
 }
 
 /// Returns the current value of the code segment register.

--- a/src/shared/task.rs
+++ b/src/shared/task.rs
@@ -5,5 +5,5 @@ pub use shared::segmentation;
 
 /// Load the task state register.
 pub unsafe fn load_tr(sel: segmentation::SegmentSelector) {
-    asm!("ltr $0" :: "r" (sel));
+    asm!("ltr $0" :: "r" (sel.bits()));
 }


### PR DESCRIPTION
This fixes the build error on latest nightly.

See rust-lang/rust#39083 and especially [this comment](https://github.com/rust-lang/rust/issues/39083#issuecomment-272935193) for details.