### PR TITLE
Make CR3 a u64 not a usize

### DIFF
--- a/src/shared/control_regs.rs
+++ b/src/shared/control_regs.rs
@@ -60,14 +60,14 @@ pub unsafe fn cr2() -> usize {
 }
 
 /// Contains page-table root pointer.
-pub unsafe fn cr3() -> usize {
-    let ret: usize;
+pub unsafe fn cr3() -> u64 {
+    let ret: u64;
     asm!("mov %cr3, $0" : "=r" (ret));
     ret
 }
 
 /// Switch page-table PML4 pointer.
-pub unsafe fn cr3_write(val: usize) {
+pub unsafe fn cr3_write(val: u64) {
     asm!("mov $0, %cr3" :: "r" (val) : "memory");
 }
 


### PR DESCRIPTION
CR3 contains the physical address of the root of the page table
structure. In 32-bit protected mode with PAE, physical addresses can
be 52-bits long. To accomodate this, CR3 should always be a u64.