### PR TITLE
Remove `#![feature(associated_consts)]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![feature(const_fn)]
 #![feature(asm)]
-#![feature(associated_consts)]
 #![no_std]
 #![cfg_attr(test, allow(unused_features))]
 


### PR DESCRIPTION
Associated consts are stable as of Rust 1.20, there is no longer a need to add a `#![feature(...)]` attribute for them.