### PR TITLE
Split up shared::segmentation into bits32::segmentation and bits64::segmentation and implement specifics of each architecture

### DIFF
--- a/src/bits32/mod.rs
+++ b/src/bits32/mod.rs
@@ -1,4 +1,5 @@
 pub mod irq;
+pub mod segmentation;
 pub mod task;
 
 #[inline(always)]

--- a/src/bits32/segmentation.rs
+++ b/src/bits32/segmentation.rs
@@ -1,0 +1,40 @@
+use core::mem::size_of;
+
+use bits32::task::*;
+use shared::descriptor;
+use shared::PrivilegeLevel;
+pub use shared::segmentation::*;
+
+/// Reload code segment register.
+/// Note this is special since we can not directly move
+/// to %cs. Instead we push the new segment selector
+/// and return value on the stack and use lretl
+/// to reload cs and continue at 1:.
+pub unsafe fn set_cs(sel: SegmentSelector) {
+    asm!("pushl $0; \
+          pushl $$1f; \
+          lretl; \
+          1:" :: "ri" (sel.bits() as usize) : "memory");
+}
+
+impl SegmentDescriptor {
+    pub fn new_memory(base: u32, limit: u32, ty: Type, accessed: bool, dpl: PrivilegeLevel) -> SegmentDescriptor {
+        let ty1 = descriptor::Type::SegmentDescriptor {
+            ty: ty,
+            accessed: accessed,
+        };
+        let flags = FLAGS_DB;
+        let seg = SegmentDescriptor::memory_or_tss(base, limit, ty1, dpl, flags);
+        seg
+    }
+
+    pub fn new_tss(tss: &TaskStateSegment, dpl: PrivilegeLevel) -> [SegmentDescriptor; 2] {
+        let tss_ptr = tss as *const TaskStateSegment;
+        let ty1 = descriptor::Type::SystemDescriptor {
+            size: true,
+            ty: descriptor::SystemType::TssAvailable,
+        };
+        let seg = SegmentDescriptor::memory_or_tss(tss_ptr as u32, size_of::<TaskStateSegment>() as u32, ty1, dpl, Flags::empty());
+        seg
+    }
+}

--- a/src/bits32/segmentation.rs
+++ b/src/bits32/segmentation.rs
@@ -28,7 +28,7 @@ impl SegmentDescriptor {
         seg
     }
 
-    pub fn new_tss(tss: &TaskStateSegment, dpl: PrivilegeLevel) -> [SegmentDescriptor; 2] {
+    pub fn new_tss(tss: &TaskStateSegment, dpl: PrivilegeLevel) -> SegmentDescriptor {
         let tss_ptr = tss as *const TaskStateSegment;
         let ty1 = descriptor::Type::SystemDescriptor {
             size: true,

--- a/src/bits64/mod.rs
+++ b/src/bits64/mod.rs
@@ -33,6 +33,7 @@ macro_rules! check_bit_fn {
 pub mod time;
 pub mod irq;
 pub mod paging;
+pub mod segmentation;
 pub mod task;
 pub mod syscall;
 pub mod sgx;

--- a/src/bits64/segmentation.rs
+++ b/src/bits64/segmentation.rs
@@ -1,0 +1,56 @@
+use core::mem::size_of;
+
+use bits64::task::*;
+use shared::descriptor;
+use shared::PrivilegeLevel;
+pub use shared::segmentation::*;
+
+/// Reload code segment register.
+/// Note this is special since we can not directly move
+/// to %cs. Instead we push the new segment selector
+/// and return value on the stack and use lretq
+/// to reload cs and continue at 1:.
+pub unsafe fn set_cs(sel: SegmentSelector) {
+    asm!("pushq $0; \
+          leaq  1f(%rip), %rax; \
+          pushq %rax; \
+          lretq; \
+          1:" :: "ri" (sel.bits() as usize) : "rax" "memory");
+}
+
+pub enum SegmentBitness {
+    Bits32,
+    Bits64,
+}
+
+impl SegmentBitness {
+    pub fn pack(self) -> Flags {
+        match self {
+            SegmentBitness::Bits32 => FLAGS_DB,
+            SegmentBitness::Bits64 => FLAGS_L,
+        }
+    }
+}
+
+impl SegmentDescriptor {
+    pub fn new_memory(base: u32, limit: u32, ty: Type, accessed: bool, dpl: PrivilegeLevel, bitness: SegmentBitness) -> SegmentDescriptor {
+        let ty1 = descriptor::Type::SegmentDescriptor {
+            ty: ty,
+            accessed: accessed,
+        };
+        let flags = bitness.pack();
+        let seg = SegmentDescriptor::memory_or_tss(base, limit, ty1, dpl, flags);
+        seg
+    }
+
+    pub fn new_tss(tss: &TaskStateSegment, dpl: PrivilegeLevel) -> [SegmentDescriptor; 2] {
+        let tss_ptr = tss as *const TaskStateSegment;
+        let ty1 = descriptor::Type::SystemDescriptor {
+            size: true,
+            ty: descriptor::SystemType::TssAvailable,
+        };
+        let seg1 = SegmentDescriptor::memory_or_tss(tss_ptr as u32, size_of::<TaskStateSegment>() as u32, ty1, dpl, Flags::empty());
+        let seg2 = SegmentDescriptor::high(tss_ptr as u64);
+        [seg1, seg2]
+    }
+}

--- a/src/bits64/task.rs
+++ b/src/bits64/task.rs
@@ -1,16 +1,11 @@
 //! Helpers to program the task state segment.
 //! See Intel 3a, Chapter 7, Section 7
 
-use shared::segmentation;
-
-pub type TaskStateDescriptorLow = segmentation::SegmentDescriptor;
-pub type TaskStateDescriptorHigh = u64;
-
 /// In 64-bit mode the TSS holds information that is not
 /// directly related to the task-switch mechanism,
 /// but is used for finding kernel level stack
 /// if interrupts arrive while in kernel mode.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C, packed)]
 pub struct TaskStateSegment {
     pub reserved: u32,

--- a/src/shared/descriptor.rs
+++ b/src/shared/descriptor.rs
@@ -45,7 +45,7 @@ impl Type {
             Type::SystemDescriptor { size, ty } =>
                 (size as u8) << 3 | (ty as u8) | FLAGS_TYPE_SYS.bits,
             Type::SegmentDescriptor { ty, accessed } =>
-                (accessed as u8)  | ty.pack()  | FLAGS_TYPE_SYS.bits,
+                (accessed as u8)  | ty.pack()  | FLAGS_TYPE_SEG.bits,
         }
     }
 }


### PR DESCRIPTION
- Provide two functions new_memory and new_tss to comfortably create memory and TSS descriptors.
  The x86-64 version of new_tss outputs an array of 2 descriptors to account for the upper bits of the TSS pointer address.
- Add a bitness parameter to the x86-64 version of new_memory to allow creating segments for 32-bit and 64-bit code.
- Fix a copy-pasta mistake in the x86 version of set_cs.
- Fix the SegmentDescriptor type flag.

I'm fully aware that these API changes are not backwards compatible. However, the merge with libcpu has already broken the API before and the x86 crate couldn't be used for x86-64 anymore since then. There simply wasn't a way to create a memory segment for 64-bit code.

My changes have been tested with https://github.com/ColinFinck/HermitCore/tree/path2rs

Fixes #25 and #26.