### PR TITLE
Update IdtEntry to the actual descriptor in Intel 3a, Figure 6-7 (including ist_index)

### DIFF
--- a/src/bits32/segmentation.rs
+++ b/src/bits32/segmentation.rs
@@ -28,7 +28,7 @@ impl SegmentDescriptor {
         seg
     }
 
-    pub fn new_tss(tss: &TaskStateSegment, dpl: PrivilegeLevel) -> [SegmentDescriptor; 2] {
+    pub fn new_tss(tss: &TaskStateSegment, dpl: PrivilegeLevel) -> SegmentDescriptor {
         let tss_ptr = tss as *const TaskStateSegment;
         let ty1 = descriptor::Type::SystemDescriptor {
             size: true,


### PR DESCRIPTION
Additionally, replace the boolean "block" by a more straightforward "ty" parameter with custom type.
Due to the custom type and assert!, we cannot keep this a "const fn", but I think code correctness outweighs this.