### PR TITLE
use x86_64 instead x86-64 as architecture target

### DIFF
--- a/src/bits64/rflags.rs
+++ b/src/bits64/rflags.rs
@@ -73,14 +73,14 @@ impl RFlags {
     }
 }
 
-#[cfg(target_arch = "x86-64")]
+#[cfg(target_arch = "x86_64")]
 pub unsafe fn read() -> RFlags {
     let r: u64;
     asm!("pushfq; popq $0" : "=r"(r) :: "memory");
     RFlags::from_bits_truncate(r)
 }
 
-#[cfg(target_arch = "x86-64")]
+#[cfg(target_arch = "x86_64")]
 pub unsafe fn set(val: RFlags) {
     asm!("pushq $0; popfq" :: "r"(val.bits()) : "memory" "flags");
 }


### PR DESCRIPTION
This patch removes only a typo in the specification of the target architecture.