### PR TITLE
add cr2_write, for example to reset CR2

### DIFF
--- a/src/controlregs.rs
+++ b/src/controlregs.rs
@@ -77,6 +77,11 @@ pub unsafe fn cr2() -> usize {
     ret
 }
 
+/// Write cr2, for instance to reset cr2
+pub unsafe fn cr2_write(val: u64) {
+    asm!("mov $0, %cr2" :: "r" (val) : "memory");
+}
+
 /// Contains page-table root pointer.
 pub unsafe fn cr3() -> u64 {
     let ret: u64;


### PR DESCRIPTION
This patch add the function cr2_write, which I use to reset the control register CR2.