### PR TITLE
perfmon_data update broke build

### DIFF
--- a/x86data/perfmon_data/mapfile.csv
+++ b/x86data/perfmon_data/mapfile.csv
@@ -77,18 +77,3 @@ GenuineIntel-6-9E,V42,/SKL/skylake_fp_arith_inst_v42.json,fp_arith_inst
 GenuineIntel-6-57,V9,/KNL/KnightsLanding_core_V9.json,core
 GenuineIntel-6-57,V9,/KNL/KnightsLanding_matrix_V9.json,offcore
 GenuineIntel-6-57,V9,/KNL/KnightsLanding_uncore_V9.json,uncore
-GenuineIntel-6-85,V9,/KNM/KnightsLanding_core_V9.json,core
-GenuineIntel-6-85,V9,/KNM/KnightsLanding_matrix_V9.json,offcore
-GenuineIntel-6-85,V9,/KNM/KnightsLanding_uncore_V9.json,uncore
-GenuineIntel-6-55-[01234],V1.12,/SKX/skylakex_core_v1.12.json,core
-GenuineIntel-6-55-[01234],V1.12,/SKX/skylakex_matrix_v1.12.json,offcore
-GenuineIntel-6-55-[01234],V1.12,/SKX/skylakex_fp_arith_inst_v1.12.json,fp_arith_inst
-GenuineIntel-6-55-[01234],V1.12,/SKX/skylakex_uncore_v1.12.json,uncore
-GenuineIntel-6-55-[01234],V1.12,/SKX/skylakex_uncore_v1.12_experimental.json,uncore experimental
-GenuineIntel-6-55-[56789ABCDEF],V1.00,/CLX/cascadelakex_core_v1.00.json,core
-GenuineIntel-6-55-[56789ABCDEF],V1.00,/CLX/cascadelakex_fp_arith_inst_v1.00.json,fp_arith_inst
-GenuineIntel-6-55-[56789ABCDEF],V1.00,/CLX/cascadelakex_uncore_v1.00.json,uncore
-GenuineIntel-6-55-[56789ABCDEF],V1.00,/CLX/cascadelakex_uncore_v1.00_experimental.json,uncore experimental
-GenuineIntel-6-7A,V1.01,/GLP/goldmontplus_core_v1.01.json,core
-GenuineIntel-6-7A,V1.01,/GLP/goldmontplus_fp_arith_inst_v1.01.json,fp_arith_inst
-GenuineIntel-6-7A,V1.01,/GLP/goldmontplus_matrix_v1.01.json,offcore


### PR DESCRIPTION
* build is failing on new perfmon_data due to several issues
* handles some cases better
* add better failure messaging
* remove any problematic microarchitectures

Unaddressed:
* PEBSCounter values in goldmontplus exceed 8 ("EventName": "INST_RETIRED.ANY", "PEBScounters": "32")
* skylakex and casecadelakex produce collision
* KNL and KNM also produces a collision