### PR TITLE
Always inline functions that operate on FLAGS register

### DIFF
--- a/src/bits32/eflags.rs
+++ b/src/bits32/eflags.rs
@@ -67,6 +67,7 @@ impl EFlags {
 }
 
 #[cfg(target_arch = "x86")]
+#[inline(always)]
 pub unsafe fn read() -> EFlags {
     let r: u32;
     asm!("pushfl; popl $0" : "=r"(r) :: "memory");
@@ -74,6 +75,7 @@ pub unsafe fn read() -> EFlags {
 }
 
 #[cfg(target_arch = "x86")]
+#[inline(always)]
 pub unsafe fn set(val: EFlags) {
     asm!("pushl $0; popfl" :: "r"(val.bits()) : "memory" "flags");
 }
@@ -88,6 +90,7 @@ pub unsafe fn set(val: EFlags) {
 ///
 /// This instruction is only valid in Ring 0 and requires
 /// that the CPU supports the instruction (check CPUID).
+#[inline(always)]
 pub unsafe fn clac() {
     asm!("clac" ::: "memory" "flags" : "volatile");
 }
@@ -102,6 +105,7 @@ pub unsafe fn clac() {
 ///
 /// This instruction is only valid in Ring 0 and requires
 /// that the CPU supports the instruction (check CPUID).
+#[inline(always)]
 pub unsafe fn stac() {
     asm!("stac" ::: "memory" "flags" : "volatile");
 }

--- a/src/bits64/rflags.rs
+++ b/src/bits64/rflags.rs
@@ -76,6 +76,7 @@ impl RFlags {
 }
 
 #[cfg(target_arch = "x86_64")]
+#[inline(always)]
 pub unsafe fn read() -> RFlags {
     let r: u64;
     asm!("pushfq; popq $0" : "=r"(r) :: "memory");
@@ -83,6 +84,7 @@ pub unsafe fn read() -> RFlags {
 }
 
 #[cfg(target_arch = "x86_64")]
+#[inline(always)]
 pub unsafe fn set(val: RFlags) {
     asm!("pushq $0; popfq" :: "r"(val.bits()) : "memory" "flags");
 }


### PR DESCRIPTION
Non-inlined functions have a [function prologue](https://en.wikipedia.org/wiki/Function_prologue) that contain instructions which can mess with the FLAGS register before we have a chance to read it.