### PR TITLE
Provide functions to read ES, SS, DS, FS, GS and TR segment registers

### DIFF
--- a/src/segmentation.rs
+++ b/src/segmentation.rs
@@ -568,6 +568,41 @@ pub fn cs() -> SegmentSelector {
     SegmentSelector::from_raw(segment)
 }
 
+/// Returns the current value of the extra segment register.
+pub fn es() -> SegmentSelector {
+    let segment: u16;
+    unsafe { asm!("mov %es, $0" : "=r" (segment) ) };
+    SegmentSelector::from_raw(segment)
+}
+
+/// Returns the current value of the stack segment register.
+pub fn ss() -> SegmentSelector {
+    let segment: u16;
+    unsafe { asm!("mov %ss, $0" : "=r" (segment) ) };
+    SegmentSelector::from_raw(segment)
+}
+
+/// Returns the current value of the data segment register.
+pub fn ds() -> SegmentSelector {
+    let segment: u16;
+    unsafe { asm!("mov %ds, $0" : "=r" (segment) ) };
+    SegmentSelector::from_raw(segment)
+}
+
+/// Returns the current value of the FS segment register.
+pub fn fs() -> SegmentSelector {
+    let segment: u16;
+    unsafe { asm!("mov %fs, $0" : "=r" (segment) ) };
+    SegmentSelector::from_raw(segment)
+}
+
+/// Returns the current value of the GS segment register.
+pub fn gs() -> SegmentSelector {
+    let segment: u16;
+    unsafe { asm!("mov %gs, $0" : "=r" (segment) ) };
+    SegmentSelector::from_raw(segment)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/task.rs
+++ b/src/task.rs
@@ -3,7 +3,14 @@
 
 pub use crate::segmentation;
 
-/// Load the task state register.
+/// Returns the current value of the task register.
+pub fn tr() -> segmentation::SegmentSelector {
+    let segment: u16;
+    unsafe { asm!("str $0" : "=r" (segment) ) };
+    segmentation::SegmentSelector::from_raw(segment)
+}
+
+/// Loads the task register.
 pub unsafe fn load_tr(sel: segmentation::SegmentSelector) {
     asm!("ltr $0" :: "r" (sel.bits()));
 }


### PR DESCRIPTION
Currently only CS can be read using `x86::segmentation::cs()`.

This PR adds functions to read the other 5 registers and to read the TR (task register).