### PR TITLE
Inline vmresume() and vmlaunch()

### DIFF
--- a/src/bits64/vmx.rs
+++ b/src/bits64/vmx.rs
@@ -77,12 +77,14 @@ pub unsafe fn vmwrite(field: u32, value: u64) -> Result<()> {
 }
 
 /// Launch virtual machine.
+#[inline(always)]
 pub unsafe fn vmlaunch() -> Result<()> {
     asm!("vmlaunch");
     vmx_capture_status()
 }
 
 /// Resume virtual machine.
+#[inline(always)]
 pub unsafe fn vmresume() -> Result<()> {
     asm!("vmresume");
     vmx_capture_status()


### PR DESCRIPTION
In #56's discussion I noted that "there are no strong reasons to use inline for VMX intrinsics".

I was wrong: it's practically impossible to use `x86::bits64::vmx::vmresume()` due to it being a function. The reason is that VMRESUME is usually called after restoring the guest state, which includes stack pointer.

As the stack pointer now corresponds to guest address space and CALL to `x86::bits64::vmx::vmresume()` accesses the stack, this results in triple fault exception.

`x86::bits64::vmx::vmlaunch()` was also inlined because in practice it has similar pitfalls, and even through they can be avoided, an inlined version of this function is less surprising.