### PR TITLE
removed #\[feature(const_fn, repr_transparent)] as these are now stable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #![allow(stable_features)]
-#![feature(const_fn, asm, repr_transparent, core_intrinsics)]
+#![feature(asm, core_intrinsics)]
 #![no_std]
 #![cfg_attr(test, allow(unused_features))]
 #![cfg_attr(all(test, feature = "vmtest"), feature(custom_test_frameworks))]


### PR DESCRIPTION
`repr_transparent` became stable in [1.28](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1280-2018-08-02)
`const_fn` in [1.31](https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html)

I dream of a world, where system level programming can be done in stable rust :smile: 