### PR TITLE
Update klogger dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ optional = true
 features = ["core"]
 
 [target.'cfg(target_family = "unix")'.dev-dependencies]
-klogger = { version = "0.0.4", features = ["use_ioports"] }
+klogger = { version = "0.0.6", features = ["use_ioports"] }
 x86test = { version = "0.0.2" }
 libc = "0.2.*"
 

--- a/x86test/Cargo.toml
+++ b/x86test/Cargo.toml
@@ -22,4 +22,4 @@ kvm-sys = "0.3.0"
 x86 = "0.32"
 mmap = "0.1.1"
 log = "0.4"
-klogger = { version = "0.0.4", features = ["use_ioports"] }
+klogger = { version = "0.0.6", features = ["use_ioports"] }


### PR DESCRIPTION
klogger v0.0.4 depended on an older version of the x86 crate:

```
x86test v0.0.3 (/home/ckuehl/git/rust-x86/x86test)
├── klogger v0.0.4
│   ├── log v0.4.11
│   │   └── cfg-if v0.1.10
│   ├── spin v0.5.2
│   ├── termcodes v0.0.1
│   └── x86 v0.21.0  <-----------------------------
```

which results in a lot of compiler errors like this when attempting to
run tests like so:

```
$ cargo test --features=utest

error: the legacy LLVM-style asm! syntax is no longer supported
  --> /home/ckuehl/.cargo/registry/src/github.com-1ecc6299db9ec823/x86-0.21.0/src/lib.rs:96:5
   |
96 |     asm!("rdpid $0" : "=r"(pid));
   |     ----^^^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     help: replace with: `llvm_asm!`
   |
   = note: consider migrating to the new asm! syntax specified in RFC 2873
   = note: alternatively, switch to llvm_asm! to keep your code working as it is
```

To sanity check this fix, I pointed the dependency to my locally edited
version:

```
Cargo.toml:
 [target.'cfg(target_family = "unix")'.dev-dependencies]
 klogger = { version = "0.0.6", features = ["use_ioports"] }
-x86test = { version = "0.0.2" }
+x86test = { path = "x86test" }
 libc = "0.2.*"

x86test/x86test_macro/Cargo.toml:
 syn = { version = "0.15", features = ["full", "extra-traits"] }
 quote = "0.6"
 proc-macro2 = "0.4"
-x86test-types = { path = "../x86test_types", version = "0.0.3" }
+x86test-types = { path = "../x86test_types" }

 [lib]
 proc-macro = true
```

and saw that the build works again for the `cargo test` target.

edit: whoops, the edit to `x86test/x86test_macro/Cargo.toml` for the sanity check was unnecessary. I must have accidentally left that in my commit message when I was moving things around.