### PR TITLE
using latest version of raw-cpuid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde_json = { version = "1.0.39", optional = true }
 [dependencies]
 bitflags = "1.*"
 bit_field = "0.10.0"
-raw-cpuid = "8.1.*"
+raw-cpuid = "9.0.*"
 
 [dependencies.phf]
 version = "0.7.7"


### PR DESCRIPTION
Using the latest version of `raw-cupid` would avoid issues like hermitcore/libhermit-rs#164