### PR TITLE
Dependabot config to keep the dependencies updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# See
+# https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-and-disabling-version-updates
+# for details
+
+version: 2
+updates:
+  # Enable crate version updates for the main crate
+  - package-ecosystem: "cargo"
+    # Look `Cargo.toml` in the repository root
+    directory: "/"
+    # Check for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+  # Enable crate version updates for x86test directory
+  - package-ecosystem: "cargo"
+    # Look `Cargo.toml` in the repository root
+    directory: "/x86test"
+    # Check for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+  # Enable version updates for Github Actions
+  - package-ecosystem: "github-actions"
+    # Set to `/` to check the Actions used in `.github/workflows`
+    directory: "/"
+    # Check for updates every day (weekdays)
+    schedule:
+      interval: "daily"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ license = "MIT"
 build = "build.rs"
 edition = '2018'
 
+exclude = ["./.github/*"]
+
 [features]
 performance-counter = ["phf", "phf_codegen", "csv", "serde_json"]
 # Note we have to choose between regular tests and x86test at the moment, so we use features


### PR DESCRIPTION
Dependabot should check if all dependencies are up to date once a day. I
added the .github folder to the exclude section of the crate so it will
not get uploaded to crates.io.