### PR TITLE
Fix performance-counter feature

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -1,0 +1,51 @@
+name: Standard checks
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+#          - stable
+#          - beta
+          - nightly
+#          - 1.31.0  # MSRV
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features performance-counter #--all-features  will currently fail
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,6 @@ optional = true
 
 [target.'cfg(target_family = "unix")'.dev-dependencies]
 klogger = { version = "0.0.6", features = ["use_ioports"] }
-x86test = { version = "0.0.3" }
+x86test = { path = "x86test" }
 libc = "0.2.*"
 

--- a/build.rs
+++ b/build.rs
@@ -361,8 +361,7 @@ mod performance_counter {
                 );
             }
         }
-        builder.build(file).unwrap();
-        write!(file, ";\n").unwrap();
+        writeln!(file, "{};", builder.build()).unwrap();
         file.flush().ok();
         // Make sure builder entries stay around (see unsafe above), and we don't accidentially drop it
         assert!(builder_values.len() > 0);
@@ -457,15 +456,13 @@ mod performance_counter {
         }
 
         // Next, we write this hash-table (COUNTER_MAP) into our generated rust code file:
-        write!(
+        writeln!(
             &mut filewriter,
-            "pub static {}: phf::Map<&'static str, phf::Map<&'static str, \
-             EventDescription<'static>>> = ",
-            "COUNTER_MAP"
+            "pub static COUNTER_MAP: phf::Map<&'static str, phf::Map<&'static str, \
+             EventDescription<'static>>> = {};",
+            builder.build()
         )
         .unwrap();
-        builder.build(&mut filewriter).unwrap();
-        write!(&mut filewriter, ";\n").unwrap();
 
         // Now, parse all JSON files with event data for each architecture and generate hash-tables
         let mut architectures: HashMap<String, Vec<String>> = HashMap::new();

--- a/x86test/Cargo.toml
+++ b/x86test/Cargo.toml
@@ -16,8 +16,8 @@ Custom test runner for bare-metal x86 tests.
 """
 
 [dependencies]
-x86test-macro = { path = "x86test_macro", version = "0.0.3" }
-x86test-types = { path = "x86test_types", version = "0.0.3" }
+x86test-macro = { path = "x86test_macro" }
+x86test-types = { path = "x86test_types" }
 kvm-sys = "0.3.0"
 x86 = "0.36.0"
 mmap = "0.1.1"

--- a/x86test/x86test_types/Cargo.toml
+++ b/x86test/x86test_types/Cargo.toml
@@ -15,4 +15,4 @@ Common types for x86test runnter and the x86test procedural macro.
 """
 
 [dependencies]
-x86 = "0.32"
+x86 = {path = "../.."}


### PR DESCRIPTION
It looks like I broke the performance-counter feature when updating the dependencies with #71 Sorry for that. This pull requests fixes this feature and also fixes the tests for the default and the performance-counter feature. Running `cargo test --all-features` still fails, but as far as I can tell, this also was the case before #71.

I have also added a GitHub Action config so that the master branch and every PR are automatically builds with default features and with all features. I hope this prevents anyone from breaking a non-default feature in the future. Again, sorry for that.