### PR TITLE
Fix the build for nightly

### DIFF
--- a/src/dtables.rs
+++ b/src/dtables.rs
@@ -50,7 +50,7 @@ impl<T> DescriptorTablePointer<T> {
 
 impl<T> fmt::Debug for DescriptorTablePointer<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        unsafe { write!(f, "DescriptorTablePointer ({} {:?})", self.limit, self.base) }
+        write!(f, "DescriptorTablePointer ({} {:?})", { self.limit }, { self.base } )
     }
 }
 

--- a/x86test/src/lib.rs
+++ b/x86test/src/lib.rs
@@ -1,5 +1,5 @@
 //! x86test infrastructure to run rust unit tests in guest-ring 0.
-#![feature(lang_items, const_fn)]
+#![feature(lang_items)]
 
 extern crate klogger;
 extern crate kvm_sys as kvm;


### PR DESCRIPTION
Fixes compiler errors and warnings that can appear on the latest nightly for the `x86` crate.
For more details see
- https://github.com/rust-lang/rust/issues/82523 about referencing packed/unaligned fields, and
- https://github.com/rust-lang/rust/issues/84510 about the removal of the `const_fn` feature gate.