### PR TITLE
perfcnt: Use `base_model_id` for looking up `COUNTER_MAP`

### DIFF
--- a/src/perfcnt/intel/mod.rs
+++ b/src/perfcnt/intel/mod.rs
@@ -47,7 +47,7 @@ macro_rules! get_events {
             cpuid.get_feature_info().map_or(None, |fi| {
                 let vendor = vf.as_str();
                 let (family, extended_model, model) =
-                    (fi.family_id(), fi.extended_model_id(), fi.model_id());
+                    (fi.base_family_id(), fi.extended_model_id(), fi.base_model_id());
 
                 let mut writer: ModelWriter = Default::default();
                 // Should work as long as it fits in MODEL_LEN bytes:


### PR DESCRIPTION
The new `model_id` function introduced as part of [this commit ](https://github.com/gz/rust-cpuid/commit/97fd82ea59b7d2ad933631dbc8ae8939845ce756) breaks the `COUNTER_MAP` lookup on https://github.com/gz/rust-perfcnt which depends on `rust-x86` crate.

- [x]  Tested on Intel
- [ ]  Tested on AMD