### PR TITLE
Add explicit `use` statements core::arch::asm.

### DIFF
--- a/src/debugregs.rs
+++ b/src/debugregs.rs
@@ -17,6 +17,8 @@
 use bit_field::BitField;
 use bitflags::bitflags;
 
+use core::arch::asm;
+
 /// An array list of all available breakpoint registers.
 pub const BREAKPOINT_REGS: [Breakpoint; 4] = [
     Breakpoint::Dr0,

--- a/src/irq.rs
+++ b/src/irq.rs
@@ -3,6 +3,7 @@
 
 use bitflags::*;
 
+use core::arch::asm;
 use core::fmt;
 
 /// x86 Exception description (see also Intel Vol. 3a Chapter 6).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![cfg_attr(all(test, feature = "vmtest"), feature(custom_test_frameworks))]
 #![cfg_attr(all(test, feature = "vmtest"), test_runner(x86test::runner::runner))]
 
+use core::arch::asm;
 #[cfg(target_arch = "x86")]
 pub(crate) use core::arch::x86 as arch;
 #[cfg(target_arch = "x86_64")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,9 +117,12 @@ mod x86testing {
 /// May fail with #UD if rdpid is not supported (check CPUID).
 #[inline(always)]
 pub unsafe fn rdpid() -> u64 {
+    #[cfg(target_pointer_width = "64")]
     let mut pid: u64;
+    #[cfg(target_pointer_width = "32")]
+    let mut pid: u32;
     asm!("rdpid {pid}", pid = out(reg) pid, options(att_syntax));
-    pid
+    pid.into()
 }
 
 #[cfg(all(test, feature = "utest"))]

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,6 +1,7 @@
 //! Helpers to program the task state segment.
 //! See Intel 3a, Chapter 7
 
+use core::arch::asm;
 pub use crate::segmentation;
 
 /// Returns the current value of the task register.

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,8 +1,8 @@
 //! Helpers to program the task state segment.
 //! See Intel 3a, Chapter 7
 
-use core::arch::asm;
 pub use crate::segmentation;
+use core::arch::asm;
 
 /// Returns the current value of the task register.
 ///

--- a/src/tlb.rs
+++ b/src/tlb.rs
@@ -1,5 +1,7 @@
 //! Functions to flush the translation lookaside buffer (TLB).
 
+use core::arch::asm;
+
 /// Invalidate the given address in the TLB using the `invlpg` instruction.
 ///
 /// # Safety


### PR DESCRIPTION
The new asm!() syntx has been stabilized in
nightly Rust, but requires either a `use`
statement or explicit package qualification.
This PR adds `use` statements in the modules
that use the new macro.  Fixes #117.

Signed-off-by: Dan Cross <cross@gajendra.net>